### PR TITLE
Increased Model Scale for Fleshcreeper

### DIFF
--- a/gamemode/zombieclasses/flesh_creeper.lua
+++ b/gamemode/zombieclasses/flesh_creeper.lua
@@ -22,8 +22,8 @@ CLASS.ModelScale = 0.75 -- was 0.65 (65% of scale of antlion model, as small as 
 --[[CLASS.ModelScale = 0.6324555
 CLASS.ClientsideModelScale = 0.4 / CLASS.ModelScale]]
 
-CLASS.Hull = {Vector(-16, -16, 0), Vector(16, 16, 36)}
-CLASS.HullDuck = {Vector(-16, -16, 0), Vector(16, 16, 36)}
+CLASS.Hull = {Vector(-19, -19, 0), Vector(19, 19, 39)}
+CLASS.HullDuck = {Vector(-19, -19, 0), Vector(19, 19, 39)}
 
 CLASS.ViewOffset = Vector(0, 0, 35.5)
 CLASS.ViewOffsetDucked = Vector(0, 0, 35.5)

--- a/gamemode/zombieclasses/flesh_creeper.lua
+++ b/gamemode/zombieclasses/flesh_creeper.lua
@@ -18,7 +18,7 @@ CLASS.VoicePitch = 0.55
 CLASS.PainSounds = {Sound("npc/barnacle/barnacle_pull1.wav"), Sound("npc/barnacle/barnacle_pull2.wav"), Sound("npc/barnacle/barnacle_pull3.wav"), Sound("npc/barnacle/barnacle_pull4.wav")}
 CLASS.DeathSounds = {Sound("npc/barnacle/barnacle_die1.wav"), Sound("npc/barnacle/barnacle_die2.wav")}
 
-CLASS.ModelScale = 0.65
+CLASS.ModelScale = 0.75 -- was 0.65 (65% of scale of antlion model, as small as some headcrabs)
 --[[CLASS.ModelScale = 0.6324555
 CLASS.ClientsideModelScale = 0.4 / CLASS.ModelScale]]
 


### PR DESCRIPTION
Looking at gmod wiki this seems to also scale hitboxes and physobj boxes, should fix issues with the size of flesh creep being too small and fitting through ridiculous sized holes, if this doesn't work just increase the factor by another 10. 